### PR TITLE
add enum for movement dir and rename misnamed "velocity" in Player.gd

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -2,6 +2,9 @@ extends Node2D
 
 export var is_healthy = true
 
+enum {UP, DOWN, LEFT, RIGHT}
+var last_dir # last movement direction
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	$AnimatedSprite.set_animation("horizontal")
@@ -9,47 +12,47 @@ func _ready():
 	
 func move_player():
 	if is_healthy and (Input.is_action_just_pressed("ui_right") or Input.is_action_just_pressed("ui_left") or Input.is_action_just_pressed("ui_up") or Input.is_action_just_pressed("ui_down")): # if healthy, check for movement
-		var movedir = {"r":false,"l":false,"u":false,"d":false}
-		# next series of lines applies velocity from movement
-		var velocity = Vector2()
+		# next series of lines applies direction of movement
+		var direction_vec = Vector2()
 		if Input.is_action_just_pressed("ui_right"):
-			velocity.x += 1
-			movedir["r"] = true
+			direction_vec.x += 1
+			last_dir = RIGHT
 		elif Input.is_action_just_pressed("ui_left"):
-			velocity.x -= 1
-			movedir["l"] = true
+			direction_vec.x -= 1
+			last_dir = LEFT
 		elif Input.is_action_just_pressed("ui_up"):
-			velocity.y -= 1
-			movedir["u"] = true
+			direction_vec.y -= 1
+			last_dir = UP
 		elif Input.is_action_just_pressed("ui_down"):
-			velocity.y += 1
-			movedir["d"] = true
+			direction_vec.y += 1
+			last_dir = DOWN
 			
-		var dest_coord = get_parent().world_to_map(position + velocity * get_parent().cell_size) # dest_coord stores the coordinates of the destination
+		var dest_coord = get_parent().world_to_map(position) + direction_vec # dest_coord stores the coordinates of the destination
 		var dest_type = get_parent().get_cellv(dest_coord) # dest_type stores the tile id of the destination tile
-		if velocity != Vector2(0,0):
+		if direction_vec != Vector2(0,0):
 			if dest_type == 1: # wall
 				pass # no movement
 			elif dest_type == 2: # spike
 				deflate() # deflates player
 			else:
-				position += velocity * get_parent().cell_size # movement occurs!
-				if movedir["r"]: # right
-					$AnimatedSprite.set_animation("horizontal") # set to horizontal animation
-					$AnimatedSprite.set_frame(0) # reset frame to first
-					$AnimatedSprite.play("",false) # play in forward direction
-				elif movedir["l"]: # left
-					$AnimatedSprite.set_animation("horizontal") # set to horizontal animation
-					$AnimatedSprite.set_frame(3) # reset frame to last
-					$AnimatedSprite.play("",true) # play in reverse direction
-				elif movedir["u"]: # up
-					$AnimatedSprite.set_animation("vertical") # set to vertical animation
-					$AnimatedSprite.set_frame(0) # reset frame to first
-					$AnimatedSprite.play("",false) # play in forward direction
-				else: # down
-					$AnimatedSprite.set_animation("vertical") # set to vertical animation
-					$AnimatedSprite.set_frame(3) # reset frame to last
-					$AnimatedSprite.play("",true) # play in reverse direction
+				position += direction_vec * get_parent().cell_size # movement occurs!
+				match last_dir:
+					RIGHT:
+						$AnimatedSprite.set_animation("horizontal") # set to horizontal animation
+						$AnimatedSprite.set_frame(0) # reset frame to first
+						$AnimatedSprite.play("",false) # play in forward direction
+					LEFT:
+						$AnimatedSprite.set_animation("horizontal") # set to horizontal animation
+						$AnimatedSprite.set_frame(3) # reset frame to last
+						$AnimatedSprite.play("",true) # play in reverse direction
+					UP:
+						$AnimatedSprite.set_animation("vertical") # set to vertical animation
+						$AnimatedSprite.set_frame(0) # reset frame to first
+						$AnimatedSprite.play("",false) # play in forward direction
+					DOWN:
+						$AnimatedSprite.set_animation("vertical") # set to vertical animation
+						$AnimatedSprite.set_frame(3) # reset frame to last
+						$AnimatedSprite.play("",true) # play in reverse direction
 				
 func deflate(): # deflates player
 	$AnimatedSprite.set_animation("deflated")


### PR DESCRIPTION
It's weird to call it a velocity when you are multiplying by tile size and not by time, so I changed the name. Also, the dict of up/down/left/right flags has been replaced by an enum which will probably come in handy for lots of things. One good use is that the big if-else tree can be replaced by ```match```