### PR TITLE
small logic improvements to boulder pushing and player moving code

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -49,7 +49,7 @@ func check_for_move_action(): # connects key to movement direction
 	return direction
 
 func complete_move(direction_vec):
-	position += direction_vec * get_parent().cell_size
+	position = get_parent().map_to_world( get_parent().world_to_map(position) + direction_vec ) + get_parent().cell_size/2
 
 func attempt_move(direction):
 	var direction_vec = dir_to_displacement_vec[direction]
@@ -62,7 +62,7 @@ func attempt_move(direction):
 		2: # spike
 			deflate() # deflates player
 		4: # hole
-			position += direction_vec * get_parent().cell_size # movement occurs...
+			complete_move(direction_vec)
 			fall() # ...much to the player's peup :D
 		_:
 			no_tile_obstacle = true

--- a/TileMap.gd
+++ b/TileMap.gd
@@ -33,19 +33,17 @@ func attempt_bouldrop(bould): # drops a boulder if it's on a hole
 		bould.knock_bould()
 
 func push_bould(bould,dir): # moves bould in a certain direction, or returns false if it can't
-	var can_move = false
 	if bould.is_topside:
 		var dest_coord = world_to_map(bould.position) + dir_to_displacement_vec[dir]
 		var dest_type = get_cellv(dest_coord)
 		if (not dest_type in obstacles) and (get_boulds_here(dest_coord).size()) == 0:
-			bould.position += dir_to_displacement_vec[dir]*cell_size
-			can_move = true
+			bould.position = map_to_world(dest_coord)+cell_size/2
 			match dir:
 				RIGHT: bould.rotate_bould("cw")
 				LEFT: bould.rotate_bould("ccw")
-		if can_move:
 			attempt_bouldrop(bould)
-	return can_move
+			return true
+	return false
 					
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 #func _process(delta):


### PR DESCRIPTION
In some places I prefered updating positions based on the output of map_to_world, rather
than by incrementing positions. I think this can prevent buildup of rounding errors from incrementing positions