### PR TITLE
fix some movement bugs and play with UI anchors

### DIFF
--- a/HUD.gd
+++ b/HUD.gd
@@ -16,11 +16,11 @@ func _on_QuitButt_pressed():
 
 func reset(lvl):
 	set_text("")
-	$MoveCounter.text = "0"
+	$MoveLabel/MoveCounter.text = "0"
 	$LvlLabel.text = "Level "+str(lvl)
 
 func increment_move_counter():
-	$MoveCounter.text = str(int($MoveCounter.text)+1)
+	$MoveLabel/MoveCounter.text = str(int($MoveLabel/MoveCounter.text)+1)
 
 func set_text(text):
 	$MsgLabel.text = text

--- a/HUD.tscn
+++ b/HUD.tscn
@@ -36,8 +36,21 @@ margin_right = -9.30164
 margin_bottom = -10.6984
 script = ExtResource( 1 )
 
-[node name="Controls" type="Sprite" parent="."]
-position = Vector2( 78.6198, 72.1774 )
+[node name="CenterContainer" type="CenterContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -72.5129
+margin_top = -22.9058
+margin_right = 2.48706
+margin_bottom = 33.0942
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="Controls" type="Sprite" parent="CenterContainer"]
+position = Vector2( 36.0125, 26.49 )
 scale = Vector2( 1, 1.04 )
 texture = ExtResource( 2 )
 
@@ -50,61 +63,69 @@ custom_fonts/font = SubResource( 1 )
 text = "Level"
 
 [node name="MsgLabel" type="Label" parent="."]
-margin_left = 108.715
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -112.285
 margin_top = 16.3016
-margin_right = 218.715
+margin_right = -2.28537
 margin_bottom = 36.3016
 custom_fonts/font = SubResource( 2 )
 
 [node name="MoveLabel" type="Label" parent="."]
-margin_left = 141.652
-margin_top = 53.9495
-margin_right = 191.652
-margin_bottom = 71.9495
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+margin_left = -79.3484
+margin_top = -11.0503
+margin_right = -29.3484
+margin_bottom = 6.94971
 custom_fonts/font = SubResource( 3 )
 text = "MOVES"
 
-[node name="MoveCounter" type="Label" parent="."]
-margin_left = 141.652
-margin_top = 74.7495
-margin_right = 181.652
-margin_bottom = 92.7495
+[node name="MoveCounter" type="Label" parent="MoveLabel"]
+margin_top = 20.8
+margin_right = 40.0
+margin_bottom = 38.8
 custom_fonts/font = SubResource( 4 )
 text = "0"
 align = 1
 
-[node name="RestartButt" type="Button" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 8.64856
-margin_top = -30.8192
-margin_right = -130.352
-margin_bottom = -6.81917
+margin_left = 14.0
+margin_top = -29.9996
+margin_right = -14.0004
+margin_bottom = -5.99957
+alignment = 1
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="RestartButt" type="Button" parent="HBoxContainer"]
+margin_right = 82.0
+margin_bottom = 24.0
+size_flags_horizontal = 0
 custom_fonts/font = SubResource( 5 )
 text = "restart"
 
-[node name="MenuButt" type="Button" parent="."]
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 99.5485
-margin_top = -30.0
-margin_right = -67.4524
-margin_bottom = -6.0
+[node name="MenuButt" type="Button" parent="HBoxContainer"]
+margin_left = 86.0
+margin_right = 138.0
+margin_bottom = 24.0
+size_flags_horizontal = 0
 custom_fonts/font = SubResource( 6 )
 text = "menu"
 
-[node name="QuitButt" type="Button" parent="."]
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 159.785
-margin_top = -30.0
-margin_right = -9.21536
-margin_bottom = -6.0
+[node name="QuitButt" type="Button" parent="HBoxContainer"]
+margin_left = 142.0
+margin_right = 194.0
+margin_bottom = 24.0
+size_flags_horizontal = 0
 custom_fonts/font = SubResource( 7 )
 text = "quit"
-[connection signal="pressed" from="RestartButt" to="." method="_on_RestartButt_pressed"]
-[connection signal="pressed" from="MenuButt" to="." method="_on_MenuButt_pressed"]
-[connection signal="pressed" from="QuitButt" to="." method="_on_QuitButt_pressed"]
+[connection signal="pressed" from="HBoxContainer/RestartButt" to="." method="_on_RestartButt_pressed"]
+[connection signal="pressed" from="HBoxContainer/MenuButt" to="." method="_on_MenuButt_pressed"]
+[connection signal="pressed" from="HBoxContainer/QuitButt" to="." method="_on_QuitButt_pressed"]

--- a/HUD.tscn
+++ b/HUD.tscn
@@ -107,7 +107,7 @@ __meta__ = {
 [node name="RestartButt" type="Button" parent="HBoxContainer"]
 margin_right = 82.0
 margin_bottom = 24.0
-size_flags_horizontal = 0
+size_flags_horizontal = 3
 custom_fonts/font = SubResource( 5 )
 text = "restart"
 
@@ -115,7 +115,7 @@ text = "restart"
 margin_left = 86.0
 margin_right = 138.0
 margin_bottom = 24.0
-size_flags_horizontal = 0
+size_flags_horizontal = 3
 custom_fonts/font = SubResource( 6 )
 text = "menu"
 
@@ -123,7 +123,7 @@ text = "menu"
 margin_left = 142.0
 margin_right = 194.0
 margin_bottom = 24.0
-size_flags_horizontal = 0
+size_flags_horizontal = 3
 custom_fonts/font = SubResource( 7 )
 text = "quit"
 [connection signal="pressed" from="HBoxContainer/RestartButt" to="." method="_on_RestartButt_pressed"]

--- a/HUD.tscn
+++ b/HUD.tscn
@@ -74,26 +74,35 @@ text = "0"
 align = 1
 
 [node name="RestartButt" type="Button" parent="."]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 8.64856
-margin_top = 98.6671
-margin_right = 90.6486
-margin_bottom = 122.667
+margin_top = -30.8192
+margin_right = -130.352
+margin_bottom = -6.81917
 custom_fonts/font = SubResource( 5 )
 text = "restart"
 
 [node name="MenuButt" type="Button" parent="."]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 99.5485
-margin_top = 98.667
-margin_right = 153.548
-margin_bottom = 122.667
+margin_top = -30.0
+margin_right = -67.4524
+margin_bottom = -6.0
 custom_fonts/font = SubResource( 6 )
 text = "menu"
 
 [node name="QuitButt" type="Button" parent="."]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 159.785
-margin_top = 100.193
-margin_right = 211.785
-margin_bottom = 124.193
+margin_top = -30.0
+margin_right = -9.21536
+margin_bottom = -6.0
 custom_fonts/font = SubResource( 7 )
 text = "quit"
 [connection signal="pressed" from="RestartButt" to="." method="_on_RestartButt_pressed"]

--- a/LevelLoader.gd
+++ b/LevelLoader.gd
@@ -1,5 +1,7 @@
 extends Node
 
+# size of loaded level in pixels
+var level_size : Vector2
 
 
 func load_level(lvl):
@@ -7,6 +9,15 @@ func load_level(lvl):
 	var level = Level.instance()
 	add_child(level)
 	
+	var used_cells : Array = level.get_used_cells()
+	var xs := Array()
+	var ys := Array()
+	for cell in used_cells:
+		xs.append(cell.x)
+		ys.append(cell.y)
+	level_size = level.get_cell_size() * Vector2(xs.max(),ys.max())
+
+
 	# connect all the signals
 	var main_node = get_parent()
 	level.connect("player_moved",main_node,"_on_player_moved")

--- a/Menu.tscn
+++ b/Menu.tscn
@@ -20,9 +20,10 @@ font_data = ExtResource( 2 )
 font_data = ExtResource( 2 )
 
 [node name="Menu" type="Panel"]
+anchor_right = 0.89
 margin_left = 350.0
 margin_top = 96.0
-margin_right = 604.0
+margin_right = -250.4
 margin_bottom = 669.0
 script = ExtResource( 1 )
 
@@ -36,6 +37,14 @@ margin_bottom = 90.8046
 custom_fonts/font = SubResource( 1 )
 text = "soko"
 
+[node name="CBoulder" type="Sprite" parent="Title"]
+position = Vector2( -22.2758, 33.3515 )
+texture = ExtResource( 3 )
+
+[node name="TBoulder" type="Sprite" parent="Title"]
+position = Vector2( 178.04, 30.7668 )
+texture = ExtResource( 4 )
+
 [node name="LevelSelectLabel" type="Label" parent="."]
 margin_left = 37.4783
 margin_top = 105.973
@@ -45,26 +54,24 @@ custom_fonts/font = SubResource( 2 )
 text = "Select level:"
 
 [node name="LevelSelectBox" type="ItemList" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 38.0
 margin_top = 135.0
-margin_right = 217.0
-margin_bottom = 506.0
+margin_right = -37.0
+margin_bottom = -67.0
 custom_fonts/font = SubResource( 3 )
 
 [node name="QuitButt" type="Button" parent="."]
-margin_left = 97.9235
-margin_top = 523.355
-margin_right = 154.924
-margin_bottom = 549.355
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -29.0765
+margin_top = -49.645
+margin_right = 27.924
+margin_bottom = -23.645
 custom_fonts/font = SubResource( 4 )
 text = "quit"
-
-[node name="CBoulder" type="Sprite" parent="."]
-position = Vector2( 23.2624, 58.1561 )
-texture = ExtResource( 3 )
-
-[node name="TBoulder" type="Sprite" parent="."]
-position = Vector2( 223.578, 55.5714 )
-texture = ExtResource( 4 )
 [connection signal="item_activated" from="LevelSelectBox" to="." method="_on_LevelSelectBox_item_activated"]
 [connection signal="pressed" from="QuitButt" to="." method="_on_QuitButt_pressed"]

--- a/Menu.tscn
+++ b/Menu.tscn
@@ -20,11 +20,13 @@ font_data = ExtResource( 2 )
 font_data = ExtResource( 2 )
 
 [node name="Menu" type="Panel"]
-anchor_right = 0.89
-margin_left = 350.0
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_bottom = 1.0
+margin_left = -130.0
 margin_top = 96.0
-margin_right = -250.4
-margin_bottom = 669.0
+margin_right = 124.0
+margin_bottom = -131.0
 script = ExtResource( 1 )
 
 [node name="Title" type="Label" parent="."]

--- a/levels/lvl_template/Player.gd
+++ b/levels/lvl_template/Player.gd
@@ -48,18 +48,15 @@ func attempt_move(direction):
 	var direction_vec = dir_to_displacement_vec[direction]
 	var dest_coord = get_parent().world_to_map(position) + direction_vec # dest_coord stores the MAP coordinates of the destination
 	var dest_type = get_parent().get_cellv(dest_coord) # dest_type stores the tile id of the destination tile
-	var no_tile_obstacle = false
+	var no_tile_obstacle = false # will set to true if player movement is obstructed by destination TILE (doesn't care about non-tile obstacles)
 	match dest_type:
 		1: # wall
 			pass
 		2: # spike
 			deflate() # deflates player
-		4: # hole
+		4, 8: # any kind of hole
 			no_tile_obstacle = true
 			fall() # ...much to the player's peup :D
-		8: # Heddood, is there a better way to do this with match? i.e. "4 or 8"? But that didn't work...
-			no_tile_obstacle = true
-			fall()
 		_:
 			no_tile_obstacle = true
 	if(no_tile_obstacle):

--- a/levels/lvl_template/Player.gd
+++ b/levels/lvl_template/Player.gd
@@ -48,24 +48,34 @@ func attempt_move(direction):
 	var direction_vec = dir_to_displacement_vec[direction]
 	var dest_coord = get_parent().world_to_map(position) + direction_vec # dest_coord stores the MAP coordinates of the destination
 	var dest_type = get_parent().get_cellv(dest_coord) # dest_type stores the tile id of the destination tile
-	var no_tile_obstacle = false # will set to true if player movement is obstructed by destination TILE (doesn't care about non-tile obstacles)
+	
+	# will set the following flag if player movement is not obstructed by destination TILE 
+	# (doesn't care about non-tile obstacles like stuck boulders)
+	var no_tile_obstacle = false 
 	match dest_type:
 		1: # wall
 			pass
 		2: # spike
 			deflate() # deflates player
-		4, 8: # any kind of hole
-			no_tile_obstacle = true
-			fall() # ...much to the player's peup :D
 		_:
 			no_tile_obstacle = true
+	
+	# in the case that no tiles have obstructed movement, handle any boulders that are in the way and possibly move
 	if(no_tile_obstacle):
 		var beuld = get_parent().get_boulds_here(dest_coord) # the list of boulders in the destination
 		if beuld.size() > 0: # if there is a boulder there...
 			if get_parent().push_bould(beuld[0],direction): # ...and, if the boulder is pushed...
-				complete_move(direction_vec) # ...then movement occurs!
+				complete_move(direction_vec)
 		else: # on the other hand, if no boulder...
-			complete_move(direction_vec) # ...movement occurs!
+			complete_move(direction_vec)
+	
+	# any movement that could have occured is now complete.
+	
+	# check if on a hole, and fall if so
+	if get_parent().get_cellv(get_parent().world_to_map(position)) in [4,8] :
+		fall()
+	
+	
 			
 func peuped(): # player's health has been compromised
 	is_healthy = false

--- a/levels/lvl_template/Player.gd
+++ b/levels/lvl_template/Player.gd
@@ -55,10 +55,10 @@ func attempt_move(direction):
 		2: # spike
 			deflate() # deflates player
 		4: # hole
-			complete_move(direction_vec)
+			no_tile_obstacle = true
 			fall() # ...much to the player's peup :D
 		8: # Heddood, is there a better way to do this with match? i.e. "4 or 8"? But that didn't work...
-			complete_move(direction_vec)
+			no_tile_obstacle = true
 			fall()
 		_:
 			no_tile_obstacle = true


### PR DESCRIPTION
The main important part of this merge will be the player movement/fall bug fix.

The original bug was that if a boulder ends up on the wrong hole, then the player can still move on top of it and fall through the boulder into the hole. It looks weird and isn't consistent with other movement rules. It's fixed now.

I was also playing with anchors and margins for the Control nodes (in the HUD and the Menu).
Nothing too great has resulted from this yet, but you can see the effect of it if you open the HUD or the Menu scene in the editor and resize the root panel node, watching how the child control nodes move around fluidly. This could eventually be useful.
(Mainly I was applying things that I learned [here](https://docs.godotengine.org/en/3.1/getting_started/step_by_step/ui_introduction_to_the_ui_system.html#there-are-two-workflows-to-build-responsive-uis) and [here](https://www.youtube.com/watch?v=6G3NP5O9VsQ&t=38s).)